### PR TITLE
Refactor API for widget and middleware factories

### DIFF
--- a/packages/framework/src/widget-core/middleware/base.ts
+++ b/packages/framework/src/widget-core/middleware/base.ts
@@ -1,7 +1,7 @@
-import { middleware } from '../tsx';
+import { createMiddlewareFactory } from '../tsx';
 import { getNode, getInvalidator, properties as vdomProperties, destroy as vdomDestroy, getRegistry } from '../vdom';
 
-const createFactory = middleware();
+const createFactory = createMiddlewareFactory();
 
 export const dom = createFactory(({ id }) => {
 	return (key: string | number): HTMLElement | null => {

--- a/packages/framework/src/widget-core/middleware/breakpoint.ts
+++ b/packages/framework/src/widget-core/middleware/breakpoint.ts
@@ -1,7 +1,7 @@
-import { middleware } from '../tsx';
+import { createMiddlewareFactory } from '../tsx';
 import { resize } from './resize';
 
-const createFactory = middleware();
+const createFactory = createMiddlewareFactory();
 
 const defaultBreakpoints: any = { SM: 0, MD: 576, LG: 768, XL: 960 };
 

--- a/packages/framework/src/widget-core/middleware/cache.ts
+++ b/packages/framework/src/widget-core/middleware/cache.ts
@@ -1,8 +1,8 @@
-import { middleware } from '../tsx';
+import { createMiddlewareFactory } from '../tsx';
 import Map from '@dojo/framework/shim/Map';
 import { destroy } from './base';
 
-const createFactory = middleware();
+const createFactory = createMiddlewareFactory();
 
 export const cache = createFactory({ destroy }, ({ middleware }) => {
 	const cacheMap = new Map<string, any>();

--- a/packages/framework/src/widget-core/middleware/intersection.ts
+++ b/packages/framework/src/widget-core/middleware/intersection.ts
@@ -1,4 +1,4 @@
-import { middleware } from '../tsx';
+import { createMiddlewareFactory } from '../tsx';
 import { dom, invalidator, destroy } from './base';
 
 export interface IntersectionResult {
@@ -26,7 +26,7 @@ const defaultIntersection: IntersectionResult = Object.freeze({
 	isIntersecting: false
 });
 
-const createFactory = middleware();
+const createFactory = createMiddlewareFactory();
 
 export const intersection = createFactory({ dom, invalidator, destroy }, ({ middleware }) => {
 	const _details = new Map<string, IntersectionDetail>();

--- a/packages/framework/src/widget-core/middleware/resize.ts
+++ b/packages/framework/src/widget-core/middleware/resize.ts
@@ -1,8 +1,8 @@
-import { middleware } from '../tsx';
+import { createMiddlewareFactory } from '../tsx';
 import ResizeObserver from '@dojo/framework/shim/ResizeObserver';
 import { dom, invalidator, destroy } from './base';
 
-const createFactory = middleware();
+const createFactory = createMiddlewareFactory();
 
 export const resize = createFactory({ dom, invalidator, destroy }, ({ middleware: { dom, invalidator, destroy } }) => {
 	const invalidate = invalidator();

--- a/packages/framework/src/widget-core/tsx.ts
+++ b/packages/framework/src/widget-core/tsx.ts
@@ -42,22 +42,22 @@ export interface WidgetResultWithMiddleware<T, MiddlewareProps> {
 		callback: (
 			options: {
 				middleware: MiddlewareApiMap<T>;
-				properties: UnionToIntersection<Props & MiddlewareProps>;
+				properties: WidgetProperties & UnionToIntersection<Props & MiddlewareProps>;
 				children: DNode[];
 			}
 		) => RenderResult
-	): WNodeFactory<{ properties: UnionToIntersection<Props & MiddlewareProps>; children: Children }>;
+	): WNodeFactory<{ properties: WidgetProperties & UnionToIntersection<Props & MiddlewareProps>; children: Children }>;
 }
 
 export interface WidgetResult {
 	<Props, Children extends DNode[] = DNode[]>(
 		callback: (
 			options: {
-				properties: Props;
+				properties: WidgetProperties & Props;
 				children: DNode[];
 			}
 		) => RenderResult
-	): WNodeFactory<{ properties: Props; children: Children }>;
+	): WNodeFactory<{ properties: WidgetProperties & Props; children: Children }>;
 }
 
 export type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends ((k: infer I) => void)
@@ -154,11 +154,11 @@ export function tsx(tag: any, properties = {}, ...children: any[]): DNode {
 	}
 }
 
-export function widget(): WidgetResult;
-export function widget<T extends MiddlewareMap<any>, MiddlewareProps = T[keyof T]['properties']>(
+export function createWidgetFactory(): WidgetResult;
+export function createWidgetFactory<T extends MiddlewareMap<any>, MiddlewareProps = T[keyof T]['properties']>(
 	middlewares: T
 ): WidgetResultWithMiddleware<T, MiddlewareProps>;
-export function widget<T extends MiddlewareMap<any>, MiddlewareProps = T[keyof T]['properties']>(
+export function createWidgetFactory<T extends MiddlewareMap<any>, MiddlewareProps = T[keyof T]['properties']>(
 	middlewares?: any
 ): any {
 	return function<Props, Children extends DNode[] = DNode[]>(
@@ -178,7 +178,7 @@ export function widget<T extends MiddlewareMap<any>, MiddlewareProps = T[keyof T
 	};
 }
 
-export function middleware<Props>() {
+export function createMiddlewareFactory<Props>() {
 	function createMiddleware<ReturnValue>(
 		callback: MiddlewareCallback<Props, {}, ReturnValue>
 	): MiddlewareResult<Props, {}, ReturnValue>;
@@ -213,3 +213,5 @@ export function middleware<Props>() {
 
 	return createMiddleware;
 }
+
+export const createWidget = createWidgetFactory();

--- a/packages/framework/src/widget-core/vdom.ts
+++ b/packages/framework/src/widget-core/vdom.ts
@@ -4,7 +4,7 @@ import { WeakMap } from '@dojo/framework/shim/WeakMap';
 import { Map } from '@dojo/framework/shim/Map';
 import { Set } from '@dojo/framework/shim/Set';
 import transitionStrategy from '@dojo/framework/widget-core/animations/cssTransitions';
-import { w, widget, isWidget } from './tsx';
+import { w, createWidget, isWidget } from './tsx';
 import { Registry, isWidgetBaseConstructor } from '@dojo/framework/widget-core/Registry';
 import { widgetInstanceMap } from '@dojo/framework/widget-core/WidgetBase';
 import { isDomVNode, isVNode, isWNode, v, WNODE, VNODE } from '@dojo/framework/widget-core/d';
@@ -442,7 +442,7 @@ function arrayFrom(arr: any) {
 function wrapNodes(renderer: () => any) {
 	const result = renderer();
 	const isWNodeWrapper = isWNode(result);
-	const App = widget()(() => {
+	const App = createWidget(() => {
 		return result;
 	});
 	(App as any).isWNodeWrapper = isWNodeWrapper;

--- a/packages/framework/tests/widget-core/unit/vdom.tsx
+++ b/packages/framework/tests/widget-core/unit/vdom.tsx
@@ -5,15 +5,15 @@ import { createResolvers } from './../support/util';
 import { stub } from 'sinon';
 
 import { renderer, getRegistry, getInvalidator, destroy, properties, getNode } from '../../../src/widget-core/vdom';
-import { middleware, widget, v, tsx } from '../../../src/widget-core/tsx';
+import { createMiddlewareFactory, createWidgetFactory, v, tsx } from '../../../src/widget-core/tsx';
 import Registry from '@dojo/framework/widget-core/Registry';
 
 const resolvers = createResolvers();
-const createMiddleware = middleware();
+const createMiddleware = createMiddlewareFactory();
 const getId = createMiddleware(({ id }) => {
 	return () => id;
 });
-const createWidget = widget({ getId });
+const createWidget = createWidgetFactory({ getId });
 
 jsdomDescribe('vdom', () => {
 	beforeEach(() => {
@@ -29,13 +29,13 @@ jsdomDescribe('vdom', () => {
 		let fooWidgetId: any;
 		let show = true;
 		const registry = new Registry();
-		const Foo = createWidget<any>(({ middleware, properties }) => {
+		const Foo = createWidget<{ foo: string }>(({ middleware, properties }) => {
 			fooWidgetId = middleware.getId();
 			return v('div', { key: 'foo' }, [properties.foo]);
 		});
 		const App = createWidget(({ middleware }) => {
 			widgetId = middleware.getId();
-			return show ? <Foo foo="bar" /> : null;
+			return show ? <Foo key="key" foo="bar" /> : null;
 		});
 		const r = renderer(() => App({}));
 		const root = document.createElement('app');


### PR DESCRIPTION
* Change `widget` to `createWidgetFactory`.
* Export a default `createWidget` function that can be used when no middleware is required
* Change `middleware` to `createMiddlewareFactory`

Also added `WidgetProperties` to all properties interfaces.